### PR TITLE
rオプションを実装しました

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,8 +3,8 @@
 require_relative 'ls_method'
 
 def main
-  option_and_path(ARGV) => { all: all, reverse: reverse, path: paths }
-  path = if paths[0].nil?
+  option_and_path(ARGV) => { all: all, reverse: reverse, paths: paths }
+  target_path = if paths[0].nil?
            './'
          else
            exit_if_not_exist(paths[0]) unless FileTest.exist?(paths[0])
@@ -13,7 +13,7 @@ def main
            %r{\S*/$}.match?(paths[0]) ? paths[0] : "#{paths[0]}/"
          end
 
-  files = get_files(path, all)
+  files = get_files(target_path, all)
   exit_if_file_not_found if files.empty?
   files.reverse! if reverse
   build_files = build_files(files)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -5,13 +5,13 @@ require_relative 'ls_method'
 def main
   option_and_path(ARGV) => { all: all, reverse: reverse, paths: paths }
   target_path = if paths[0].nil?
-           './'
-         else
-           exit_if_not_exist(paths[0]) unless FileTest.exist?(paths[0])
-           exit_file_is_true(paths[0]) if FileTest.file?(paths[0])
-           # ディレクトリの記述が/で終わっているかいないかで分岐
-           %r{\S*/$}.match?(paths[0]) ? paths[0] : "#{paths[0]}/"
-         end
+                  './'
+                else
+                  exit_if_not_exist(paths[0]) unless FileTest.exist?(paths[0])
+                  exit_file_is_true(paths[0]) if FileTest.file?(paths[0])
+                  # ディレクトリの記述が/で終わっているかいないかで分岐
+                  %r{\S*/$}.match?(paths[0]) ? paths[0] : "#{paths[0]}/"
+                end
 
   files = get_files(target_path, all)
   exit_if_file_not_found if files.empty?

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,7 +3,7 @@
 require_relative 'ls_method'
 
 def main
-  option_and_path(ARGV) => { all: all, path: paths }
+  option_and_path(ARGV) => { all: all, reverse: reverse, path: paths }
   path = if paths[0].nil?
            './'
          else
@@ -15,6 +15,7 @@ def main
 
   files = get_files(path, all)
   exit_if_file_not_found if files.empty?
+  files.reverse! if reverse
   build_files = build_files(files)
   print_files(build_files)
 end

--- a/04.ls/ls_method.rb
+++ b/04.ls/ls_method.rb
@@ -16,9 +16,11 @@ COLORS = {
 def option_and_path(arguments)
   opt = OptionParser.new
   all = false
+  reverse = false
   opt.on('-a') { |v| all = v }
+  opt.on('-r') { |v| reverse = v }
   paths = opt.parse(arguments)
-  { all: all, path: paths }
+  { all: all, reverse: reverse, path: paths }
 end
 
 def exit_if_not_exist(path)

--- a/04.ls/ls_method.rb
+++ b/04.ls/ls_method.rb
@@ -20,7 +20,7 @@ def option_and_path(arguments)
   opt.on('-a') { |v| all = v }
   opt.on('-r') { |v| reverse = v }
   paths = opt.parse(arguments)
-  { all: all, reverse: reverse, path: paths }
+  { all: all, reverse: reverse, paths: paths }
 end
 
 def exit_if_not_exist(path)


### PR DESCRIPTION
aオプション実装の際に指摘いただいた命名の件も少し修正を加えました。一旦この現状からls5の時に再度検討してみたいと思います🙇‍♂️（紛らわしくて今後ミスにつながりそうだったのでこのタイミングで一度修正を加えさせていただきました）

>[nits] paths の名前(複数形)で 戻り値を受け取っているものの、用事があるのは paths[0] のみなので、うまくその辺りの矛盾を option_and_path() にて吸収してくれているともっとスッキリ使えそうだなと思いました。

これに関しては、OSのlsコマンドが引数として複数のパスを受け取って実行できる仕様であったため、今後そのように拡張できる余地を残す意図でpathsを戻り値として渡しています。これらを実装に移すためにはエラーハンドリングの動作も少し見直しが必要で、手間がかかりそうだったため優先度を鑑みて一旦未実装です。そのためpathsを渡しているのに使用するのはpath[0]だけ、という矛盾が発生しています。

変数名の修正の意図は[変数を明確に区別するために修正](https://github.com/s-tone-gs/ruby-practices/pull/7/commits/d8be06964fb18b88b11f89618efce82b571456d3)内のコメントに記述しました。🙇‍♂️